### PR TITLE
Update generator.py to sample individual images

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,15 @@ Here, `model_name` follows the notation of `source_target`, e.g. `ffhq_sketches`
 CUDA_VISIBLE_DEVICES=0 python generate.py --ckpt_target ./checkpoints/ffhq_sketches.pt --load_noise noise.pt
 ```
 
-This will save the images in the `test_samples/` directory.
+This will save the images in the `test_samples/` directory.  
+
+```bash
+CUDA_VISIBLE_DEVICES=0 python generate.py --ckpt_target ./checkpoints/ffhq_babies.pt --n_samples 100 --mode individual
+```
+This will generate individual `--n_samples` images from `--ckpt_target` and save the images in the `individual_samples/` directory.  
+This individually generated images will be used to compute FID scores.  
+  
+  
 
 ### Visualizing correspondence results
 

--- a/generate.py
+++ b/generate.py
@@ -52,7 +52,6 @@ def generate_gif(args, g_list, device, mean_latent):
 
 
 def generate_imgs(args, g_list, device, mean_latent):
-
     with torch.no_grad():
         for i in range(len(g_list)):
             g_test = g_list[i]
@@ -75,6 +74,21 @@ def generate_imgs(args, g_list, device, mean_latent):
          normalize=True,
          range=(-1, 1),
          )
+
+def generate_individual_imgs(args,g_list,device,mean_latent):
+    with torch.no_grad():
+        for i in range(len(g_list)):
+            g_test=g_list[i]
+            g_test.eval()
+            for j in range(args.n_sample):
+                sample_z=torch.randn(1, args.latent, device=device)
+                sample, _ = g_test([sample_z], truncation=args.truncation, truncation_latent=mean_latent, input_is_latent=False, randomize_noise=False)
+                utils.save_image(
+                    sample,
+                    f'individual_samples/gen%d_%d.png' % (i,j),
+                    normalize=True,
+                    range=(-1,1),
+                )
 
 if __name__ == '__main__':
     device = 'cuda'
@@ -128,4 +142,5 @@ if __name__ == '__main__':
         generate_imgs(args, g_list, device, mean_latent)
     elif args.mode == 'interpolate':
         generate_gif(args, g_list, device, mean_latent)
-
+    elif args.mode == 'individual':
+        generate_individual_imgs(args, g_list, device, mean_latent)


### PR DESCRIPTION
When computing FID scores, there need some sampled outputs.  
So, I added some minor features to generate.py to sample images individually.  
Also, I updated README.md to describe how to use this new feature.